### PR TITLE
Update buildkit version and disable cgroup setup

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
               value: "true"
             - name: BUILDKIT_TLS_ENABLED
               value: "false"
+            - name: EARTHLY_SKIP_CGROUP_SETUP
+              value: "true"
             - name: CACHE_SIZE_MB
               value: "45000"
             # - name: BUILDKIT_SCHEDULER_DEBUG

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: earthly/buildkitd
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.6.10"
+  tag: "v0.7.4"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Updated builldkit version
Disabled cgroup setup as suggested [in this earthly issue](https://github.com/earthly/earthly/issues/2746#issuecomment-1454131016).